### PR TITLE
Update lts-18.10; Stack 2.7.3; ubuntu base image

### DIFF
--- a/.semaphore/build.sh
+++ b/.semaphore/build.sh
@@ -6,5 +6,5 @@ mkdir --parents .stack/root .stack/work output/bin output/lib
 ./stack.sh --local-bin-path output/bin build --copy-bins apply-refact brittany hasktags hlint stan stylish-haskell weeder
 cache store stack .stack
 strip output/bin/*
-./stack.sh exec -- sh -c 'target="$PWD/output/lib" && cd "$STACK_ROOT/programs/x86_64-linux/ghc-tinfo6-8.10.4/lib/ghc-8.10.4" && cp --recursive --target-directory "$target" --verbose llvm-passes llvm-targets package.conf.d platformConstants settings'
+./stack.sh exec -- sh -c 'target="$PWD/output/lib" && cd "$STACK_ROOT/programs/x86_64-linux/ghc-tinfo6-8.10.7/lib/ghc-8.10.7" && cp --recursive --target-directory "$target" --verbose llvm-passes llvm-targets package.conf.d platformConstants settings'
 artifact push workflow output --expire-in 1w

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Default pipeline
 agent:
   machine:
-    type: e1-standard-2
+    type: e1-standard-8
     os_image: ubuntu1804
 
 blocks:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -2,7 +2,7 @@ version: v1.0
 name: Default pipeline
 agent:
   machine:
-    type: e1-standard-8
+    type: e1-standard-2
     os_image: ubuntu1804
 
 blocks:

--- a/brittany/Dockerfile
+++ b/brittany/Dockerfile
@@ -1,2 +1,3 @@
+FROM ubuntu:focal-20210827
 COPY ghc-lib/ /home/semaphore/docker-tools/.stack/root/programs/x86_64-linux/ghc-tinfo6-8.10.7/lib/ghc-8.10.7/
 COPY brittany /usr/local/bin/

--- a/brittany/Dockerfile
+++ b/brittany/Dockerfile
@@ -1,3 +1,2 @@
-FROM amazonlinux:2.0.20200722.0
-COPY ghc-lib/ /home/semaphore/docker-tools/.stack/root/programs/x86_64-linux/ghc-tinfo6-8.10.4/lib/ghc-8.10.4/
+COPY ghc-lib/ /home/semaphore/docker-tools/.stack/root/programs/x86_64-linux/ghc-tinfo6-8.10.7/lib/ghc-8.10.7/
 COPY brittany /usr/local/bin/

--- a/hasktags/Dockerfile
+++ b/hasktags/Dockerfile
@@ -1,2 +1,2 @@
-FROM amazonlinux:2.0.20200722.0
+FROM ubuntu:focal-20210827
 COPY hasktags /usr/local/bin/

--- a/hlint/Dockerfile
+++ b/hlint/Dockerfile
@@ -1,4 +1,3 @@
-FROM amazonlinux:2.0.20200722.0
-COPY ghc-lib/ /home/semaphore/docker-tools/.stack/root/programs/x86_64-linux/ghc-tinfo6-8.10.4/lib/ghc-8.10.4/
+COPY ghc-lib/ /home/semaphore/docker-tools/.stack/root/programs/x86_64-linux/ghc-tinfo6-8.10.7/lib/ghc-8.10.7/
 COPY hlint /usr/local/bin/
 COPY refactor /usr/local/bin/

--- a/hlint/Dockerfile
+++ b/hlint/Dockerfile
@@ -1,3 +1,4 @@
+FROM ubuntu:focal-20210827
 COPY ghc-lib/ /home/semaphore/docker-tools/.stack/root/programs/x86_64-linux/ghc-tinfo6-8.10.7/lib/ghc-8.10.7/
 COPY hlint /usr/local/bin/
 COPY refactor /usr/local/bin/

--- a/itprotv.cabal
+++ b/itprotv.cabal
@@ -4,11 +4,11 @@ version: 0
 build-type: Simple
 library
   build-depends:
-    base == 4.14.1.0
-    , apply-refact == 0.8.2.1
-    , brittany == 0.13.1.0
-    , hasktags == 0.71.2
-    , hlint == 3.2.6
+    base == 4.14.3.0
+    , apply-refact == 0.9.1.0
+    , brittany == 0.13.1.2
+    , hasktags == 0.72.0
+    , hlint == 3.2.7
     , stan == 0.0.1.0
-    , stylish-haskell == 0.12.2.0
-    , weeder == 2.1.3
+    , stylish-haskell == 0.13.0.0
+    , weeder == 2.2.0

--- a/stack.sh
+++ b/stack.sh
@@ -8,5 +8,5 @@ exec docker run \
   --tty \
   --volume "$PWD:$PWD" \
   --workdir "$PWD" \
-  itprotv/stack:v2.5.1 \
+  itprotv/stack:2.7.3 \
   stack --allow-different-user --color never --jobs 2 --no-terminal "$@"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,25 @@
-resolver: https://raw.githubusercontent.com/EdutainmentLIVE/snapshot/d3fc895f40d93214fa8d9def7cc32f19329a6c0c/snapshot.yaml
-extra-deps:
-  - brittany-0.13.1.0
-  - data-tree-print-0.1.0.2
-  - dhall-1.37.1
-  - dir-traverse-0.2.3.0
-  - hasktags-0.71.2
-  - json-0.10
-  - microaeson-0.1.0.0
-  - pretty-simple-3.2.3.0
-  - trial-tomland-0.0.0.0
-  - weeder-2.1.3
+resolver: https://raw.githubusercontent.com/EdutainmentLIVE/snapshot/90180da23fba9f20aff085cdd27c5d9c0a7066ea/snapshot.yaml
 
-  # https://github.com/kowainik/colourista/pull/46
+# WARNING: Ignoring stan's bounds on pretty-simple (^>=3.2); using pretty-simple-4.0.0.0.
+# WARNING: Ignoring stan's bounds on slist (^>=0.1); using slist-0.2.0.0.
+# WARNING: Ignoring trial's bounds on dlist (^>=0.8.0.8); using dlist-1.0.
+allow-newer: true
+
+extra-deps:
+  - apply-refact-0.9.1.0
+  - brittany-0.13.1.2
+  - data-tree-print-0.1.0.2
+  - dhall-1.40.1
+  - dir-traverse-0.2.3.0
+  - generic-lens-2.2.0.0
+  - generic-lens-core-2.2.0.0
+  - ghc-exactprint-0.6.3.4
+  - microaeson-0.1.0.0
+  - stylish-haskell-0.13.0.0
+  - trial-tomland-0.0.0.0
+  - weeder-2.2.0
+
+    # https://github.com/kowainik/colourista/pull/46
   - git: https://github.com/kowainik/colourista
     commit: c73154cd46c44fa710f4ae2d21c3fbacf65b8007
 
@@ -22,10 +30,6 @@ extra-deps:
   # https://github.com/kowainik/stan/pull/398
   - git: https://github.com/kowainik/stan
     commit: 86977865db1cd2e46985fc5e787d84cb880e0af4
-
-  # https://github.com/jaspervdj/stylish-haskell/pull/336
-  - git: https://github.com/jaspervdj/stylish-haskell
-    commit: 8f8034c833a93f2dc8d0fc0a9a6f8806fbc1766e
 
   # https://github.com/kowainik/trial/pull/63
   - git: https://github.com/kowainik/trial

--- a/stan/Dockerfile
+++ b/stan/Dockerfile
@@ -1,2 +1,2 @@
-FROM amazonlinux:2.0.20200722.0
+FROM ubuntu:focal-20210827
 COPY stan /usr/local/bin/

--- a/stylish-haskell/Dockerfile
+++ b/stylish-haskell/Dockerfile
@@ -1,3 +1,2 @@
-FROM amazonlinux:2.0.20200722.0
-COPY ghc-lib/ /home/semaphore/docker-tools/.stack/root/programs/x86_64-linux/ghc-tinfo6-8.10.4/lib/ghc-8.10.4/
+COPY ghc-lib/ /home/semaphore/docker-tools/.stack/root/programs/x86_64-linux/ghc-tinfo6-8.10.7/lib/ghc-8.10.7/
 COPY stylish-haskell /usr/local/bin/

--- a/stylish-haskell/Dockerfile
+++ b/stylish-haskell/Dockerfile
@@ -1,2 +1,3 @@
+FROM ubuntu:focal-20210827
 COPY ghc-lib/ /home/semaphore/docker-tools/.stack/root/programs/x86_64-linux/ghc-tinfo6-8.10.7/lib/ghc-8.10.7/
 COPY stylish-haskell /usr/local/bin/

--- a/weeder/Dockerfile
+++ b/weeder/Dockerfile
@@ -1,2 +1,2 @@
-FROM amazonlinux:2.0.20200722.0
+FROM ubuntu:focal-20210827
 COPY weeder /usr/local/bin/


### PR DESCRIPTION
Change:
- Update to latest snapshot that includes lts-18.10
- Update to stack 2.7.3
  - Its base image is now ubuntu and matches the base image used in stack 2.7.4 image

---

- [ ] I manually tested the code locally to make sure that it works.
- [ ] If there is documentation, I made sure it's accurate and up to date.
- [ ] If possible, I wrote automated tests for the new behavior.
